### PR TITLE
feat: #16 Include host machine environment details

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,61 @@ This method accepts the following arguments:
 - `category`: A custom value used to arbitrarily group this Breadcrumb.
 - `customData`: Any custom data you want to record about application state when the Breadcrumb was recorded.
 
+### Environment details
+
+Raygun for Blazor captures environment details differently depending on the platform where the error originated.
+
+The availability of each environment detail properties depend on the platform itself, so some of them may not be always available.
+
+For more information, you can check the `EnvironmentDetails.cs` file.
+
+#### Browser environment details
+
+When the application is running on a browser, for example when using Blazor WebAssembly, or when running MAUI Blazor Hybrid applications on mobile, the attached environment details are obtained from the browser layer on the client side.
+
+For example:
+
+```json
+"environment": {
+  "browser-Height": 982,
+  "browserName": "Mozilla",
+  "browser-Width": 1512,
+  "color-Depth": 24,
+  // etc ...
+}
+```
+
+#### Server environment details
+
+When the application is running on a server machine, for example when using Blazor Server, or when running MAUI Blazor Hybrid applications on desktop, the attached environment details are obtained from the operating system of the running platform.
+
+For example:
+
+```json
+"environment": {
+  "architecture": "X64",
+  "availablePhysicalMemory": 1,
+  "cpu": "X64",
+  "deviceName": "WINDOWS-PC",
+  // etc ...
+}
+```
+
+The client side environment details from the browser, if available, will be also attached as part of the **User Custom Data** under `BrowserEnvironment`:
+
+```json
+"userCustomData": {
+  "BrowserEnvironment": {
+    "browser-Height": 1392,
+    "browser": "Google",
+    "browserName": "Chrome",
+    "browser-Version": "129.0.6668.100",
+    "browser-Width": 2560,
+    // etc ...
+  }
+}   
+```
+
 ### Attaching user details
 
 Raygun for Blazor provides two ways to attach user details to error reports:

--- a/src/Raygun.Blazor/Models/EnvironmentDetails.cs
+++ b/src/Raygun.Blazor/Models/EnvironmentDetails.cs
@@ -230,9 +230,7 @@ namespace Raygun.Blazor.Models
             // Couldn't find a way to obtain Model or Manufacturer.
             DeviceName = Environment.MachineName,
 
-            // Convert Bytes to Gygabytes
-            // Each drive is listed individually
-            DiskSpaceFree = System.IO.DriveInfo.GetDrives().Select(d => Convert.ToDouble(d.TotalFreeSpace / 1024 / 1024 / 1024)).ToList(),
+            DiskSpaceFree = GetDiskSpaceFree(),
 
             Locale = System.Globalization.CultureInfo.CurrentCulture.Name,
             OSVersion = Environment.OSVersion.Version.ToString(),
@@ -250,6 +248,22 @@ namespace Raygun.Blazor.Models
             TotalVirtualMemory = Convert.ToUInt64(Process.GetCurrentProcess().VirtualMemorySize64 / 1024 / 1024),
 #pragma warning restore CA1416 // Validate platform compatibility
         };
+
+        static private List<double> GetDiskSpaceFree()
+        {
+            try
+            {
+                // Convert Bytes to Gygabytes
+                // Each drive is listed individually
+                return System.IO.DriveInfo.GetDrives().Select(d => Convert.ToDouble(d.TotalFreeSpace / 1024 / 1024 / 1024)).ToList();
+            }
+            catch (Exception)
+            {
+                // If we can't get the disk space, return an empty list.
+                // e.g. "System.IO.IOException: The device is not ready" when running on CI.
+                return [];
+            }
+        }
 
         #endregion
 

--- a/src/Raygun.Blazor/Models/EnvironmentDetails.cs
+++ b/src/Raygun.Blazor/Models/EnvironmentDetails.cs
@@ -212,7 +212,8 @@ namespace Raygun.Blazor.Models
         /// Creates a new instance of the <see cref="EnvironmentDetails" /> using runtime information.
         /// </summary>
         /// <remarks>
-        /// This method should not be called from Browser code (i.e. Blazor WebAssembly).
+        /// Some of the properties are not available in all environments.
+        /// e.g. Browsers, Android and iOS cannot access Process information.
         /// </remarks>
         /// <returns>
         /// Environment details for the current runtime.
@@ -239,7 +240,7 @@ namespace Raygun.Blazor.Models
             ProcessorCount = Environment.ProcessorCount,
             UtcOffset = (int)DateTimeOffset.Now.Offset.TotalHours,
 
-            // Disable warning on platform compatibility: Process not available for "browser"
+            // Disable warning on platform compatibility: Process not available on all platforms.
 #pragma warning disable CA1416 // Validate platform compatibility
             // Memory values obtained in Bytes and must be converted to Megabytes
             // Working Set: The amount of physical memory, in bytes, allocated for the associated process.

--- a/src/Raygun.Blazor/Models/EventDetails.cs
+++ b/src/Raygun.Blazor/Models/EventDetails.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 namespace Raygun.Blazor.Models
 {
 
+
     /// <summary>
     /// 
     /// </summary>
@@ -86,7 +87,7 @@ namespace Raygun.Blazor.Models
         /// These will be searchable on the dashboard.
         /// </remarks>
         [JsonInclude]
-        public Dictionary<string, string>? UserCustomData { get; set; }
+        public Dictionary<string, object>? UserCustomData { get; set; }
 
         #endregion
 

--- a/src/Raygun.Blazor/RaygunBlazorClient.cs
+++ b/src/Raygun.Blazor/RaygunBlazorClient.cs
@@ -218,18 +218,22 @@ namespace Raygun.Blazor
             }
 
             EnvironmentDetails? environment;
-            if (OperatingSystem.IsLinux() || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+            if (OperatingSystem.IsBrowser() || OperatingSystem.IsIOS() || OperatingSystem.IsAndroid())
             {
-                // If running on Server or Desktop device (MAUI Hybrid), obtain environment details from the runtime
-                environment = EnvironmentDetails.FromRuntime();
-                // Add browser details to userCustomData
-                userCustomData ??= [];
-                userCustomData.Add("BrowserEnvironment", await _browserInterop.GetBrowserEnvironment());
-            }
+                // If running on browser (e.g. WebAssembly)
+                // or Mobile MAUI Blazor Hybrid apps (iOS or Android),
+                // obtain environment details from the browser
+                environment = await _browserInterop.GetBrowserEnvironment();
+            } 
             else
             {
-                // If running Browser or Mobile device (MAUI Hybrid), obtain environment details from the browser
-                environment = await _browserInterop.GetBrowserEnvironment();
+                // If running on Server (Linux, Windows, MacOS, etc.)
+                // or Desktop MAUI Hybrid apps (Windows or Mac Catalyst),
+                // obtain environment details from the runtime
+                environment = EnvironmentDetails.FromRuntime();
+                // Add user browser details to userCustomData
+                userCustomData ??= [];
+                userCustomData.Add("BrowserEnvironment", await _browserInterop.GetBrowserEnvironment());
             }
 
 

--- a/src/Raygun.Blazor/RaygunBlazorClient.cs
+++ b/src/Raygun.Blazor/RaygunBlazorClient.cs
@@ -218,18 +218,18 @@ namespace Raygun.Blazor
             }
 
             EnvironmentDetails? environment;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
             {
-                // If running on Browser, obtain environment details from the browser
-                environment = await _browserInterop.GetBrowserEnvironment();
-            }
-            else
-            {
-                // If running on Server, obtain environment details from the runtime
+                // If running on Server or Desktop device (MAUI Hybrid), obtain environment details from the runtime
                 environment = EnvironmentDetails.FromRuntime();
                 // Add browser details to userCustomData
                 userCustomData ??= [];
                 userCustomData.Add("BrowserEnvironment", await _browserInterop.GetBrowserEnvironment());
+            }
+            else
+            {
+                // If running Browser or Mobile device (MAUI Hybrid), obtain environment details from the browser
+                environment = await _browserInterop.GetBrowserEnvironment();
             }
 
 

--- a/src/Raygun.Blazor/RaygunBlazorClient.cs
+++ b/src/Raygun.Blazor/RaygunBlazorClient.cs
@@ -224,7 +224,7 @@ namespace Raygun.Blazor
                 // or Mobile MAUI Blazor Hybrid apps (iOS or Android),
                 // obtain environment details from the browser
                 environment = await _browserInterop.GetBrowserEnvironment();
-            } 
+            }
             else
             {
                 // If running on Server (Linux, Windows, MacOS, etc.)

--- a/src/Raygun.Blazor/RaygunBlazorClient.cs
+++ b/src/Raygun.Blazor/RaygunBlazorClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -194,7 +195,7 @@ namespace Raygun.Blazor
         public async Task RecordExceptionAsync(Exception ex,
             UserDetails? userDetails = null,
             List<string>? tags = null,
-            Dictionary<string, string>? userCustomData = null,
+            Dictionary<string, object>? userCustomData = null,
             CancellationToken cancellationToken = default)
         {
             _raygunLogger?.Verbose("[RaygunBlazorClient] Recording exception: " + ex);
@@ -216,12 +217,28 @@ namespace Raygun.Blazor
                 user = await _userManager!.GetCurrentUser();
             }
 
+            EnvironmentDetails? environment;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")))
+            {
+                // If running on Browser, obtain environment details from the browser
+                environment = await _browserInterop.GetBrowserEnvironment();
+            }
+            else
+            {
+                // If running on Server, obtain environment details from the runtime
+                environment = EnvironmentDetails.FromRuntime();
+                // Add browser details to userCustomData
+                userCustomData ??= [];
+                userCustomData.Add("BrowserEnvironment", await _browserInterop.GetBrowserEnvironment());
+            }
+
+
             var request = new RaygunRequest
             {
                 Details = new EventDetails(appVersion)
                 {
                     Breadcrumbs = _breadcrumbs.ToList(),
-                    Environment = await _browserInterop.GetBrowserEnvironment(),
+                    Environment = environment,
                     Error = new ErrorDetails(ex),
                     Tags = tags,
                     User = user,

--- a/src/Raygun.Blazor/RaygunBrowserInterop.cs
+++ b/src/Raygun.Blazor/RaygunBrowserInterop.cs
@@ -28,7 +28,7 @@ namespace Raygun.Blazor
         private readonly IRaygunLogger? _raygunLogger;
         private readonly IWindowService _windowService;
         private Action<string, BreadcrumbType, string?, Dictionary<string, object>?, string?>? _breadcrumbAction;
-        private Func<Exception, UserDetails?, List<string>?, Dictionary<string, string>?, CancellationToken, Task>? _exceptionAction;
+        private Func<Exception, UserDetails?, List<string>?, Dictionary<string, object>?, CancellationToken, Task>? _exceptionAction;
 
         #endregion
 
@@ -119,7 +119,7 @@ namespace Raygun.Blazor
         /// <param name="customData"></param>
         /// <returns></returns>
         [JSInvokable]
-        public async ValueTask RecordJsException(JSError error, List<string>? tags = null, Dictionary<string, string>? customData = null)
+        public async ValueTask RecordJsException(JSError error, List<string>? tags = null, Dictionary<string, object>? customData = null)
         {
             _raygunLogger?.Verbose("[RaygunBrowserInterop] Recording JS exception: " + error.Message);
             var exception = new WebIDLException($"{error.Name}: \"{error.Message}\"", error.Stack, error.InnerException);
@@ -155,7 +155,7 @@ namespace Raygun.Blazor
         /// <param name="exceptionAction"></param>
         internal async Task InitializeAsync(Func<ErrorEvent, Task> onUnhandledJsException,
             Action<string, BreadcrumbType, string?, Dictionary<string, object>?, string?>? breadcrumbAction,
-            Func<Exception, UserDetails?, List<string>?, Dictionary<string, string>?, CancellationToken, Task>? exceptionAction)
+            Func<Exception, UserDetails?, List<string>?, Dictionary<string, object>?, CancellationToken, Task>? exceptionAction)
         {
             _breadcrumbAction = breadcrumbAction;
             _exceptionAction = exceptionAction;

--- a/src/Raygun.Samples.Blazor.Maui/MauiProgram.cs
+++ b/src/Raygun.Samples.Blazor.Maui/MauiProgram.cs
@@ -29,8 +29,8 @@ namespace Raygun.Samples.Blazor.Maui
             builder.Services.AddMauiBlazorWebView();
 
 #if DEBUG
-    		builder.Services.AddBlazorWebViewDeveloperTools();
-    		builder.Logging.AddDebug();
+            builder.Services.AddBlazorWebViewDeveloperTools();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/src/Raygun.Tests.Blazor/RaygunBlazorClientTests.cs
+++ b/src/Raygun.Tests.Blazor/RaygunBlazorClientTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -131,6 +133,22 @@ namespace Raygun.Tests.Blazor
             // Check user details from FakeRaygunUserProvider
             raygunMsg.Details.User.FullName.Should().Be("Manager User");
             raygunMsg.Details.User.Email.Should().Be("manager@example.com");
+
+            // Check Environment details
+            raygunMsg.Details.Environment.Architecture.Should().NotBeEmpty();
+            raygunMsg.Details.Environment.Cpu.Should().NotBeEmpty();
+            raygunMsg.Details.Environment.DeviceName.Should().NotBeEmpty();
+            raygunMsg.Details.Environment.OSVersion.Should().NotBeEmpty();
+            raygunMsg.Details.Environment.ProcessorCount.Should().NotBeNull();
+            raygunMsg.Details.Environment.UtcOffset.Should().NotBeNull();
+            raygunMsg.Details.Environment.TotalPhysicalMemory.Should().NotBeNull();
+            raygunMsg.Details.Environment.TotalVirtualMemory.Should().NotBeNull();
+
+            // Check Browser environment details from UserCustomData
+            var browserEnvJson = raygunMsg.Details.UserCustomData["BrowserEnvironment"];
+            browserEnvJson.Should().NotBeNull();
+            var browserEnv = JsonSerializer.Deserialize<EnvironmentDetails>((JsonElement)browserEnvJson, _jsonSerializerOptions)!;
+            browserEnv.BrowserName.Should().Be("Firefox");
         }
 
         /// <summary>

--- a/src/Raygun.Tests.Blazor/SerializationTests.cs
+++ b/src/Raygun.Tests.Blazor/SerializationTests.cs
@@ -88,8 +88,9 @@ namespace Raygun.Tests.Blazor
             result.Details.Tags[1].Should().Be("tag 2");
             result.Details.Tags[2].Should().Be("tag-3");
             result.Details.UserCustomData.Should().NotBeNull().And.HaveCount(2);
-            result.Details.UserCustomData["domain"].Should().Be("WORKPLACE");
-            result.Details.UserCustomData["area"].Should().Be("51");
+            // Cast to String to avoid issues with the dynamic object type.
+            result.Details.UserCustomData["domain"].ToString().Should().Be("WORKPLACE");
+            result.Details.UserCustomData["area"].ToString().Should().Be("51");
             result.Details.Request.Should().NotBeNull();
             result.Details.Request.HostName.Should().Be("https://raygun.io");
             result.Details.Request.Url.Should().Be("/documentation/integrations/api");


### PR DESCRIPTION
## feat: #16 Include host machine environment details

### Description :memo:

- **Purpose**: Extend Environment details with information from the host machine (if available)
- **Approach**: 
  - When running as web server on Desktop MAUI applications, collect the process and OS information we cannot obtain from the browser, attach it as environment details. Still collect the browser details from the client and attach them in the custom data.
  - When running as browser app (in WebAssembly mode) or a Mobile MAUI app, only the browser details are provided.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Updates**

- Added `EnvironmentDetails.FromRuntime()` which creates an `EnvironmentDetails` instance based on the platform runtime.
- Modified the `UserCustomData` to accept any kind of json data and not just strings.
- Modified the `RecordExceptionAsync` method to attach environment data depending on the platform.
- Added tests to verify the environment data.

### Test plan :test_tube:

- Test on different machines (Windows, Linux, MacOs). As MAUI, Server and WebAssembly apps.
- Implemented unit tests.

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)