### PR TITLE
feat: Support Net 9.0

### DIFF
--- a/src/Raygun.Blazor.Server/Raygun.Blazor.Server.csproj
+++ b/src/Raygun.Blazor.Server/Raygun.Blazor.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
         <RootNamespace>Raygun.Blazor.Server</RootNamespace>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Raygun.Blazor.WebAssembly/Raygun.Blazor.WebAssembly.csproj
+++ b/src/Raygun.Blazor.WebAssembly/Raygun.Blazor.WebAssembly.csproj
@@ -31,8 +31,12 @@
         <SupportedPlatform Include="browser" />
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.*" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="[9.*, 10.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="[8.*, 9.0.0)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Raygun.Blazor.WebAssembly/Raygun.Blazor.WebAssembly.csproj
+++ b/src/Raygun.Blazor.WebAssembly/Raygun.Blazor.WebAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
         <RootNamespace>Raygun.Blazor.WebAssembly</RootNamespace>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Raygun.Blazor/Raygun.Blazor.csproj
+++ b/src/Raygun.Blazor/Raygun.Blazor.csproj
@@ -44,6 +44,12 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[9.*, 10.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="[9.*, 10.0.0)" />
+        <PackageReference Include="Microsoft.JSInterop" Version="[9.*, 10.0.0)" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="[8.*, 9.0.0)" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="[8.*, 9.0.0)" />

--- a/src/Raygun.Blazor/Raygun.Blazor.csproj
+++ b/src/Raygun.Blazor/Raygun.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <DocumentationFile>$(DocumentationFile)\$(AssemblyName).xml</DocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <AddRazorSupportForMvc>true</AddRazorSupportForMvc>

--- a/src/Raygun.Samples.Blazor.Server/Raygun.Samples.Blazor.Server.csproj
+++ b/src/Raygun.Samples.Blazor.Server/Raygun.Samples.Blazor.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- disable caching for testing purposes -->

--- a/src/Raygun.Samples.Blazor.WebAssembly/Raygun.Samples.Blazor.WebAssembly.csproj
+++ b/src/Raygun.Samples.Blazor.WebAssembly/Raygun.Samples.Blazor.WebAssembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
     <RootNamespace>Raygun.Samples.Blazor.WebAssembly</RootNamespace>
     <Nullable>enable</Nullable>
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.*" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.*" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Raygun.Tests.Blazor.Server/Raygun.Tests.Blazor.Server.csproj
+++ b/src/Raygun.Tests.Blazor.Server/Raygun.Tests.Blazor.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Raygun.Tests.Blazor.Server</RootNamespace>

--- a/src/Raygun.Tests.Blazor/Raygun.Tests.Blazor.csproj
+++ b/src/Raygun.Tests.Blazor/Raygun.Tests.Blazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;</TargetFrameworks>
+		<TargetFramework>net9.0</TargetFramework>
 		<RootNamespace>Raygun.Tests.Blazor</RootNamespace>
 	</PropertyGroup>
 


### PR DESCRIPTION
## feat: Support Net 9.0

### Description :memo:

- **Purpose**: Support NET 9
- **Approach**: Adopt NET 9 in sample projects and update packages acordingly
- https://github.com/MindscapeHQ/raygun4blazor/issues/61

**Type of change**

- [x] New feature (non-breaking change which adds functionality)


**Updates**

To support both apps targetting Net 8.0 and Net 9.0, the following projects are set to target both frameworks, and define dependencies for either the two:

- These projects support both targets `net8.0` and `net9.0`:
  - Raygun.Blazor
  - Raygun.Blazor.Server
  - Raygun.Blazor.WebAssembly

As well, the corresponding samples and test projects have been updated

 - Sample projects migrated to use `net9.0`:
  - Raygun.Samples.Blazor.Server
  - Raygun.Samples.Blazor.WebAssembly
- Test projects migrated to use `net9.0`:
  - Raygun.Tests.Blazor
  - Raygun.Tests.Blazor.Server

To align with Raygun 4 MAUI, the MAUI projects are still on net8.0:

- These projects are still using `net8.0` frameworks:
  - Raygun.Blazor.Maui uses `net8.0-android`, `net8.0-ios` etc.
  - Raygun.Samples.Blazor.Maui remains in `net8.0`

### Test plan :test_tube:

- Build and unit tests work
- Run the sample projects

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)