### PR TITLE
fix: #64 call to parent OnErrorAsync in RaygunErrorBoundary

### DIFF
--- a/src/Raygun.Blazor.Maui/Control/RaygunErrorBoundary.cs
+++ b/src/Raygun.Blazor.Maui/Control/RaygunErrorBoundary.cs
@@ -49,7 +49,9 @@ namespace Raygun.Blazor.Maui
         /// <returns></returns>
         protected override async Task OnErrorAsync(Exception exception)
         {
-            Console.WriteLine("OnErrorAsync");
+            // Always call to parent OnErrorAsync to log the error with default logger.
+            await base.OnErrorAsync(exception);
+
             if (!RaygunSettings.Value.CatchUnhandledExceptions) return;
 
             await RaygunClient.RecordExceptionAsync(exception, null, ["UnhandledException", "Blazor", ".NET"]);

--- a/src/Raygun.Blazor.Server/Controls/RaygunErrorBoundary.cs
+++ b/src/Raygun.Blazor.Server/Controls/RaygunErrorBoundary.cs
@@ -49,6 +49,9 @@ namespace Raygun.Blazor.Server.Controls
         /// <returns></returns>
         protected override async Task OnErrorAsync(Exception exception)
         {
+            // Always call to parent OnErrorAsync to log the error with default logger.
+            await base.OnErrorAsync(exception);
+
             if (!RaygunSettings.Value.CatchUnhandledExceptions) return;
 
             await RaygunClient.RecordExceptionAsync(exception, null, ["UnhandledException", "Blazor", ".NET"]);

--- a/src/Raygun.Blazor.WebAssembly/Controls/RaygunErrorBoundary.cs
+++ b/src/Raygun.Blazor.WebAssembly/Controls/RaygunErrorBoundary.cs
@@ -14,7 +14,6 @@ namespace Raygun.Blazor.WebAssembly.Controls
     /// </summary>
     public class RaygunErrorBoundary : ErrorBoundary
     {
-
         #region Internal Parameters
 
         /// <summary>
@@ -56,6 +55,9 @@ namespace Raygun.Blazor.WebAssembly.Controls
         /// <returns></returns>
         protected override async Task OnErrorAsync(Exception exception)
         {
+            // Always call to parent OnErrorAsync to log the error with default logger.
+            await base.OnErrorAsync(exception);
+
             if (!RaygunSettings.Value.CatchUnhandledExceptions) return;
 
             await RaygunClient.RecordExceptionAsync(exception, null, ["UnhandledException", "Blazor", ".NET"]);

--- a/src/Raygun.Blazor.WebAssembly/Controls/RaygunErrorBoundary.cs
+++ b/src/Raygun.Blazor.WebAssembly/Controls/RaygunErrorBoundary.cs
@@ -14,6 +14,7 @@ namespace Raygun.Blazor.WebAssembly.Controls
     /// </summary>
     public class RaygunErrorBoundary : ErrorBoundary
     {
+
         #region Internal Parameters
 
         /// <summary>


### PR DESCRIPTION
## fix: #64 call to parent OnErrorAsync in RaygunErrorBoundary

### Description :memo:

- **Purpose**: `RaygunErrorBoundary.OnErrorAsync` only called to the internal Raygun logger and ignored the default `ErrorBoundaryLogger`.
- **Approach**: Call to the parent `OnErrorAsync` so the default implementation works independently to Raygun's configuration.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Add call to `base.OnErrorAsync` to the `RaygunErrorBoundary` implementations for WebAssembly, Maui and Server.

### Screenshots :camera:

Error captured by the parent ErrorBoundary as appearing on a Blazor Maui Windows app:

![image](https://github.com/user-attachments/assets/c67e7514-dc7b-4ba7-8f42-d2669cdb283d)

Same error as appears on Raygun

![image](https://github.com/user-attachments/assets/2df32754-8533-4b36-ab3e-56afdbaf17a9)


### Test plan :test_tube:

- Tested on samples app for Maui (Windows), WebAssembly and Server

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)