### PR TITLE
fix: support UtfOffset as decimal

### DIFF
--- a/src/Raygun.Blazor/Models/BrowserSpecs.cs
+++ b/src/Raygun.Blazor/Models/BrowserSpecs.cs
@@ -127,7 +127,7 @@ namespace Raygun.Blazor.Models
         /// <summary>
         /// UTC offset in minutes. From `new Date().getTimezoneOffset() / -60`.
         /// </summary>
-        public int UtcOffset { get; set; }
+        public decimal UtcOffset { get; set; }
 
         #endregion
 

--- a/src/Raygun.Blazor/Models/EnvironmentDetails.cs
+++ b/src/Raygun.Blazor/Models/EnvironmentDetails.cs
@@ -157,7 +157,7 @@ namespace Raygun.Blazor.Models
         /// <summary>
         /// Number of hours offset from UTC.
         /// </summary>
-        public int? UtcOffset { get; set; }
+        public decimal? UtcOffset { get; set; }
 
         #endregion
 


### PR DESCRIPTION
## fix: #69 support UtfOffset as decimal

### Description :memo:

- **Purpose**: Fixes error where code attempts to set a `decimal` into an `int`
- **Approach**: The `UtfOffset` property changes from `int` to `decimal`

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Updated `BrowserSpecs` and `EnvironmentDetails`.

### Test plan :test_tube:

Tested with WebAssembly sample project and setting local machine timezone to +0845 (in Australia).

The `UtfOffset` gets reported as `"utcOffset": 8.75` in the payload

### Author to check :eyeglasses:

- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)