### PR TITLE
chore: release 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.0.3
+
+- chore: Bump Microsoft.AspNetCore.Components from 10.0.5 to 10.0.7 (#110) (2026-05-05)
+- chore: Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.1 (#112) (2026-05-05)
+- chore: Bump Microsoft.Extensions.DependencyInjection from 10.0.5 to 10.0.7 (#111) (2026-05-05)
+- chore: Bump Microsoft.SourceLink.GitHub from 10.0.201 to 10.0.203 (#113) (2026-05-05)
+- chore: Bump Microsoft.TestPlatform from 17.14.1 to 18.5.1 (#114) (2026-05-05)
+- chore: Bump FluentAssertions from 8.8.0 to 8.9.0 (#104) (2026-04-29)
+- chore: Bump Microsoft.Extensions.DependencyInjection from 10.0.3 to 10.0.5 (#106) (2026-04-01)
+- chore: Bump Microsoft.SourceLink.GitHub from 10.0.103 to 10.0.201 (#107) (2026-04-01)
+- chore: Bump Microsoft.AspNetCore.Components from 10.0.3 to 10.0.5 (#105) (2026-04-01)
+- chore: Bump bunit from 2.6.2 to 2.7.2 (#103) (2026-04-01)
+
 ## 2.0.2
 
 - chore: Bump Microsoft.Extensions.DependencyInjection from 10.0.2 to 10.0.3 (#99) (2026-03-02)

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.2</Version>
-    <PackageVersion>2.0.2</PackageVersion>
+    <Version>2.0.3</Version>
+    <PackageVersion>2.0.3</PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## chore: Release 2.0.3

### Description :memo:

- **Purpose**: Prepares the `2.0.3` patch release of `Raygun.Blazor`. This release rolls up dependency bumps merged since `2.0.2` so they ship in a published NuGet package.
- **Approach**: Bumps `Version` and `PackageVersion` in `src/Version.props` to `2.0.3` and adds a corresponding `2.0.3` entry to `CHANGELOG.md` summarising the included Dependabot updates, following the process in `RELEASING.md`.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**

:point_right: Bump `Version`/`PackageVersion` to `2.0.3` in `src/Version.props`.
:point_right: Add `2.0.3` section to `CHANGELOG.md` listing the dependency bumps included in this release.
:point_right: Dependency bumps rolled up:
- bunit 2.6.2 → 2.7.2 (#103)
- FluentAssertions 8.8.0 → 8.9.0 (#104)
- Microsoft.AspNetCore.Components 10.0.3 → 10.0.7 (#105, #110)
- Microsoft.Extensions.DependencyInjection 10.0.3 → 10.0.7 (#106, #111)
- Microsoft.SourceLink.GitHub 10.0.103 → 10.0.203 (#107, #113)
- Microsoft.NET.Test.Sdk 18.3.0 → 18.5.1 (#112)
- Microsoft.TestPlatform 17.14.1 → 18.5.1 (#114)

### Screenshots :camera:

N/A — release metadata only, no UI changes.

### Test plan :test_tube:

1. Check out `release/2.0.3` and run `dotnet build` for the solution — confirm all projects build successfully against the bumped dependencies.
2. Run the full test suite (`dotnet test`) and confirm all unit tests pass with the updated `bunit`, `FluentAssertions`, `Microsoft.AspNetCore.Components`, `Microsoft.NET.Test.Sdk`, and `Microsoft.TestPlatform` versions.
3. Verify the "Build and Pack NuGet Packages" CI workflow succeeds for the release branch and produces `.nupkg` artifacts whose version is `2.0.3`.
4. Inspect the generated `Raygun.Blazor.2.0.3.nupkg` metadata and confirm the package version, assembly version, and SourceLink data are correct.
5. Confirm `CHANGELOG.md` lists the `2.0.3` entry above `2.0.2` with all seven dependency bumps and correct PR numbers/dates.

### Author to check :eyeglasses:

- [ ] Project and all contained modules builds successfully
- [ ] Self-/dev-tested
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)
