### PR TITLE
fix: remove KristofferStrube.Blazor.Window dependency to resolve iOS/Safari crashes

### DIFF
--- a/src/Raygun.Blazor.Maui/Extensions/MauiExtensions.cs
+++ b/src/Raygun.Blazor.Maui/Extensions/MauiExtensions.cs
@@ -1,5 +1,4 @@
-﻿using KristofferStrube.Blazor.Window;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Hosting;
@@ -18,7 +17,6 @@ namespace Raygun.Blazor.Maui
 
             builder.Services.Configure<RaygunSettings>(builder.Configuration.GetSection(configSectionName));
             builder.Services.AddScoped<RaygunBrowserInterop>();
-            builder.Services.AddScoped<IWindowService, WindowService>();
 
             builder.Services.AddHttpClient("Raygun")
                 .ConfigureHttpClient((sp, client) =>

--- a/src/Raygun.Blazor.Server/Extensions/HostBuilderExtensions.cs
+++ b/src/Raygun.Blazor.Server/Extensions/HostBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using KristofferStrube.Blazor.Window;
 using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,7 +24,6 @@ namespace Raygun.Blazor.Server.Extensions
         {
             builder.Services.Configure<RaygunSettings>(builder.Configuration.GetSection(configSectionName));
             builder.Services.AddScoped<RaygunBrowserInterop>();
-            builder.Services.AddScoped<IWindowService, WindowService>();
             builder.Services.AddScoped<IBackgroundSendStrategy, TimerBasedSendStrategy>();
             builder.Services.AddScoped<IRaygunOfflineStore, RaygunLocalOfflineStore>();
 

--- a/src/Raygun.Blazor.WebAssembly/Extensions/WebAssemblyHostBuilderExtensions.cs
+++ b/src/Raygun.Blazor.WebAssembly/Extensions/WebAssemblyHostBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using KristofferStrube.Blazor.Window;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -31,7 +30,6 @@ namespace Raygun.Blazor.WebAssembly.Extensions
         {
             builder.Services.Configure<RaygunSettings>(builder.Configuration.GetSection(configSectionName));
             builder.Services.AddSingleton<RaygunBrowserInterop>();
-            builder.Services.AddSingleton<IWindowService, WindowService>();
 
             builder.Services.AddHttpClient("Raygun")
                 .ConfigureHttpClient((sp, client) =>

--- a/src/Raygun.Blazor/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Raygun.Blazor/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Http.Headers;
-using KristofferStrube.Blazor.Window;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -45,7 +44,6 @@ namespace Raygun.Blazor.Extensions
         {
             services.Configure<RaygunSettings>(configuration.GetSection(configSectionName));
             services.AddScoped<RaygunBrowserInterop>();
-            services.AddWindowService();
 
             services.AddHttpClient("Raygun")
                 .ConfigureHttpClient((sp, client) =>

--- a/src/Raygun.Blazor/JsUnhandledException.cs
+++ b/src/Raygun.Blazor/JsUnhandledException.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace Raygun.Blazor
+{
+    /// <summary>
+    /// Represents an unhandled JavaScript exception captured from the browser and
+    /// forwarded to .NET for reporting to Raygun.
+    /// </summary>
+    /// <remarks>
+    /// Replaces the previous dependency on KristofferStrube.Blazor.WebIDL's
+    /// WebIDLException so Raygun owns the JS-error contract end-to-end.
+    /// </remarks>
+    public class JsUnhandledException : Exception
+    {
+        /// <summary>
+        /// The JavaScript error name (e.g. "TypeError"). May be null when the
+        /// browser dispatches an ErrorEvent without a backing Error object.
+        /// </summary>
+        public string? JsName { get; }
+
+        /// <summary>
+        /// The script URL the error originated from, when available.
+        /// </summary>
+        public string? FileName { get; }
+
+        /// <summary>
+        /// The line number the error originated from, when available.
+        /// </summary>
+        public int? LineNumber { get; }
+
+        /// <summary>
+        /// The column number the error originated from, when available.
+        /// </summary>
+        public int? ColumnNumber { get; }
+
+        private readonly string? _stackTrace;
+
+        /// <inheritdoc />
+        public override string? StackTrace => _stackTrace ?? base.StackTrace;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="JsUnhandledException" /> class.
+        /// </summary>
+        public JsUnhandledException(string? name, string? message, string? stack,
+            string? fileName = null, int? lineNumber = null, int? columnNumber = null)
+            : base(string.IsNullOrEmpty(message) ? (name ?? "JavaScript error") : message)
+        {
+            JsName = name;
+            _stackTrace = stack;
+            FileName = fileName;
+            LineNumber = lineNumber;
+            ColumnNumber = columnNumber;
+        }
+    }
+}

--- a/src/Raygun.Blazor/Models/ErrorDetails.cs
+++ b/src/Raygun.Blazor/Models/ErrorDetails.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection.PortableExecutable;
 using System.Text.Json.Serialization;
-using KristofferStrube.Blazor.WebIDL.Exceptions;
 using Raygun.Blazor.Extensions;
 using NonGeneric = System.Collections;
 
@@ -94,22 +93,22 @@ namespace Raygun.Blazor.Models
         /// <param name="ex">The <see cref="Exception" /> to use to populate this <see cref="ErrorDetails" /> instance.</param>
         internal ErrorDetails(Exception ex)
         {
-            if (ex is WebIDLException webIdlException)
+            if (ex is JsUnhandledException jsException)
             {
                 // JS Exception
-                ClassName = webIdlException.GetType().FullName;
-                Data = webIdlException.Data;
-                Message = webIdlException.Message;
-                if (webIdlException.StackTrace != null)
+                ClassName = jsException.JsName ?? jsException.GetType().FullName;
+                Data = jsException.Data;
+                Message = jsException.Message;
+                if (jsException.StackTrace != null)
                 {
-                    var frames = webIdlException.StackTrace.Split('\n')
+                    var frames = jsException.StackTrace.Split('\n')
                         .Where(frame => !string.IsNullOrWhiteSpace(frame));
-                    StackTrace = frames.Select(frame => new StackTraceDetails(frame)).ToList();
+                    StackTrace = frames.Select(frame => new StackTraceDetails(frame.Trim())).ToList();
                 }
 
-                if (webIdlException.InnerException is not null)
+                if (jsException.InnerException is not null)
                 {
-                    InnerError = new ErrorDetails(webIdlException.InnerException);
+                    InnerError = new ErrorDetails(jsException.InnerException);
                 }
             }
             else

--- a/src/Raygun.Blazor/Models/JsErrorPayload.cs
+++ b/src/Raygun.Blazor/Models/JsErrorPayload.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace Raygun.Blazor.Models
+{
+    /// <summary>
+    /// Plain DTO carrying details of a JavaScript error from the browser to .NET.
+    /// </summary>
+    /// <remarks>
+    /// Populated by the Raygun JS handler in Raygun.Blazor.ts and passed to
+    /// <see cref="RaygunBrowserInterop.RecordJsException(JsErrorPayload, System.Collections.Generic.List{string}?, System.Collections.Generic.Dictionary{string, object}?)" />.
+    /// All fields are optional because browsers (notably iOS/Safari and cross-origin
+    /// scripts) frequently dispatch ErrorEvents whose `error` property is null.
+    /// </remarks>
+    public class JsErrorPayload
+    {
+        /// <summary>
+        /// The error name (e.g. "TypeError"). May be null when the source is a
+        /// cross-origin "Script error." with no Error reference.
+        /// </summary>
+        [JsonInclude]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// The error message.
+        /// </summary>
+        [JsonInclude]
+        public string? Message { get; set; }
+
+        /// <summary>
+        /// The raw JavaScript stack string, newline-separated frames.
+        /// </summary>
+        [JsonInclude]
+        public string? Stack { get; set; }
+
+        /// <summary>
+        /// The script URL the error originated from, when available.
+        /// </summary>
+        [JsonInclude]
+        public string? FileName { get; set; }
+
+        /// <summary>
+        /// The line number the error originated from, when available.
+        /// </summary>
+        [JsonInclude]
+        public int? LineNumber { get; set; }
+
+        /// <summary>
+        /// The column number the error originated from, when available.
+        /// </summary>
+        [JsonInclude]
+        public int? ColumnNumber { get; set; }
+    }
+}

--- a/src/Raygun.Blazor/Raygun.Blazor.csproj
+++ b/src/Raygun.Blazor/Raygun.Blazor.csproj
@@ -34,7 +34,6 @@
 
     <ItemGroup>
         <PackageReference Include="Ben.Demystifier" Version="[0.*, 1.0.0)" />
-        <PackageReference Include="KristofferStrube.Blazor.Window" Version="0.*-*" />
         <PackageReference Include="MyCSharp.HttpUserAgentParser" Version="[3.*, 4.0.0]" />
         <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.8.3" Condition="'$(TargetFramework)' == 'net10.0'">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Raygun.Blazor/RaygunBlazorClient.cs
+++ b/src/Raygun.Blazor/RaygunBlazorClient.cs
@@ -9,8 +9,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using KristofferStrube.Blazor.WebIDL.Exceptions;
-using KristofferStrube.Blazor.Window;
 using Microsoft.Extensions.Options;
 using Raygun.Blazor.Events;
 using Raygun.Blazor.Interfaces;
@@ -154,7 +152,7 @@ namespace Raygun.Blazor
         {
             if (_browserInterop.RaygunScriptReference is null)
             {
-                await _browserInterop.InitializeAsync(OnUnhandledJsException, RecordBreadcrumb, RecordExceptionAsync);
+                await _browserInterop.InitializeAsync(RecordBreadcrumb, RecordExceptionAsync);
                 _raygunLogger?.Debug("[RaygunBlazorClient] JavaScript Interop initialized.");
             }
         }
@@ -401,26 +399,6 @@ namespace Raygun.Blazor
 
             // If we get here, the message was not sent successfully.
             return false;
-        }
-
-        /// <summary>
-        /// Processes unhandled exceptions from JavaScript and reports them to Raygun.
-        /// </summary>
-        /// <param name="errorEvent">The <see cref="ErrorEvent" /> passed up from the DOM.</param>
-        /// <remarks>
-        /// This method signature is passed to the <see cref="RaygunBrowserInterop" /> during initialization.
-        /// </remarks>
-        private async Task OnUnhandledJsException(ErrorEvent errorEvent)
-        {
-            _raygunLogger?.Verbose("[RaygunBlazorClient] Unhandled JavaScript exception caught: " + errorEvent);
-            WebIDLException? exception = await errorEvent.GetErrorAsExceptionAsync();
-            if (exception is null)
-            {
-                _raygunLogger?.Warning("[RaygunBlazorClient] Failed to convert JavaScript error to WebIDLException.");
-                return;
-            }
-
-            await RecordExceptionAsync(exception, null, ["UnhandledException", "Blazor", "JavaScript"]);
         }
 
         #endregion

--- a/src/Raygun.Blazor/RaygunBrowserInterop.cs
+++ b/src/Raygun.Blazor/RaygunBrowserInterop.cs
@@ -1,12 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using KristofferStrube.Blazor.DOM;
-using KristofferStrube.Blazor.WebIDL;
-using KristofferStrube.Blazor.WebIDL.Exceptions;
-using KristofferStrube.Blazor.Window;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
 using Raygun.Blazor.Logging;
@@ -22,11 +18,9 @@ namespace Raygun.Blazor
         #region Private Members
 
         private readonly DotNetObjectReference<RaygunBrowserInterop> _dotNetReference;
-        private EventListener<ErrorEvent>? _errorEventListener;
         private readonly IJSRuntime _jsRuntime;
         private readonly RaygunSettings _raygunSettings;
         private readonly IRaygunLogger? _raygunLogger;
-        private readonly IWindowService _windowService;
         private Action<string, BreadcrumbType, string?, Dictionary<string, object>?, string?, BreadcrumbLevel>? _breadcrumbAction;
         private Func<Exception, UserDetails?, List<string>?, Dictionary<string, object>?, CancellationToken, Task>? _exceptionAction;
 
@@ -54,11 +48,6 @@ namespace Raygun.Blazor
         /// </summary>
         internal BrowserStats? LatestBrowserStats { get; private set; }
 
-        /// <summary>
-        /// A reference to the Browser's Window object, in case we want to do other things with it.
-        /// </summary>
-        internal Window? Window { get; private set; }
-
         #endregion
 
         #region Constructors
@@ -69,9 +58,6 @@ namespace Raygun.Blazor
         /// <param name="jsRuntime">
         /// The <see cref="IJSRuntime" /> instance to use for JS Interop.
         /// </param>
-        /// <param name="windowService">
-        /// The <see cref="WindowService" /> used to get a reference to the Browser Window object.
-        /// </param>
         /// <param name="raygunSettings">
         /// The <see cref="RaygunSettings" /> instance from DI to use in configuring exception handling
         /// .</param>
@@ -79,12 +65,10 @@ namespace Raygun.Blazor
         //      See https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-8.0#avoid-trimming-javascript-invokable-net-methods
         [DynamicDependency(nameof(RecordJsBreadcrumb))]
         [DynamicDependency(nameof(RecordJsException))]
-        public RaygunBrowserInterop(IJSRuntime jsRuntime, IWindowService windowService,
-            IOptions<RaygunSettings> raygunSettings)
+        public RaygunBrowserInterop(IJSRuntime jsRuntime, IOptions<RaygunSettings> raygunSettings)
         {
             _dotNetReference = DotNetObjectReference.Create(this);
             _jsRuntime = jsRuntime;
-            _windowService = windowService;
             _raygunSettings = raygunSettings.Value;
             _raygunLogger = RaygunLogger.Create(raygunSettings.Value.LogLevel);
             _raygunLogger?.Verbose("[RaygunBrowserInterop] Created.");
@@ -114,18 +98,48 @@ namespace Raygun.Blazor
         }
 
         /// <summary>
-        /// 
+        /// Method invoked by JavaScript to record an exception. Accepts a Raygun-owned
+        /// <see cref="JsErrorPayload" /> so we never depend on browser-side WebIDL marshalling
+        /// (which crashed when ErrorEvent.error was null on iOS/Safari).
         /// </summary>
-        /// <param name="error">JavaScript Error object</param>
-        /// <param name="tags"></param>
-        /// <param name="customData"></param>
+        /// <param name="error">JavaScript error payload built by Raygun.Blazor.ts.</param>
+        /// <param name="tags">Optional tags to attach to the report.</param>
+        /// <param name="customData">Optional custom data to attach to the report.</param>
         /// <returns></returns>
         [JSInvokable]
-        public async ValueTask RecordJsException(JSError error, List<string>? tags = null, Dictionary<string, object>? customData = null)
+        public async ValueTask RecordJsException(JsErrorPayload error, List<string>? tags = null, Dictionary<string, object>? customData = null)
         {
-            _raygunLogger?.Verbose("[RaygunBrowserInterop] Recording JS exception: " + error.Message);
-            var exception = new WebIDLException($"{error.Name}: \"{error.Message}\"", error.Stack, error.InnerException);
-            await _exceptionAction!.Invoke(exception, null, tags, customData, CancellationToken.None);
+            if (error is null)
+            {
+                _raygunLogger?.Warning("[RaygunBrowserInterop] RecordJsException called with null payload; ignoring.");
+                return;
+            }
+
+            _raygunLogger?.Verbose("[RaygunBrowserInterop] Recording JS exception: " + (error.Message ?? error.Name));
+
+            if (_exceptionAction is null)
+            {
+                _raygunLogger?.Warning("[RaygunBrowserInterop] Exception action not yet wired; dropping JS exception.");
+                return;
+            }
+
+            var exception = new JsUnhandledException(
+                error.Name,
+                error.Message,
+                error.Stack,
+                error.FileName,
+                error.LineNumber,
+                error.ColumnNumber);
+
+            try
+            {
+                await _exceptionAction.Invoke(exception, null, tags, customData, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                // The error monitoring SDK must never become a source of unhandled errors itself.
+                _raygunLogger?.Error("[RaygunBrowserInterop] Failed to record JS exception: " + ex.Message);
+            }
         }
 
         #endregion
@@ -152,10 +166,9 @@ namespace Raygun.Blazor
         /// <summary>
         /// Properly configures Raygun Blazor for use with JavaScript.
         /// </summary>
-        /// <param name="onUnhandledJsException"></param>
         /// <param name="breadcrumbAction"></param>
         /// <param name="exceptionAction"></param>
-        internal async Task InitializeAsync(Func<ErrorEvent, Task> onUnhandledJsException,
+        internal async Task InitializeAsync(
             Action<string, BreadcrumbType, string?, Dictionary<string, object>?, string?, BreadcrumbLevel>? breadcrumbAction,
             Func<Exception, UserDetails?, List<string>?, Dictionary<string, object>?, CancellationToken, Task>? exceptionAction)
         {
@@ -168,10 +181,6 @@ namespace Raygun.Blazor
                 "./_content/Raygun.Blazor/Raygun.Blazor.js");
             _raygunLogger?.Verbose("[RaygunBrowserInterop] Registered Raygun Blazor script.");
 
-            // RWM: Register the .NET reference with JS so that JS code can also manually create Bookmarks and report Exceptions.
-            await _jsRuntime.InvokeVoidAsync("window.raygunBlazor.initialize", _dotNetReference);
-            _raygunLogger?.Verbose("[RaygunBrowserInterop] Registered .NET reference with JS.");
-
             // RWM: Get and cache the BrowserSpecs so we can use them later.
             BrowserSpecs = await RaygunScriptReference.InvokeAsync<BrowserSpecs>("getBrowserSpecs");
             BrowserSpecs.ParseUserAgent();
@@ -181,14 +190,15 @@ namespace Raygun.Blazor
             if (!_raygunSettings.CatchUnhandledExceptions)
             {
                 _raygunLogger?.Verbose("[RaygunBrowserInterop] Unhandled exceptions configured not being caught.");
+                // RWM: Register the .NET reference so manual JS-side reportException / recordBreadcrumb still work.
+                await _jsRuntime.InvokeVoidAsync("window.raygunBlazor.initialize", _dotNetReference);
                 return;
             }
 
-            // RWM: Register a handler for unhandled JS exceptions.
-            Window = await _windowService.GetWindowAsync();
-            _errorEventListener = await EventListener<ErrorEvent>.CreateAsync(_jsRuntime, onUnhandledJsException);
-            await Window.AddOnErrorEventListenerAsync(_errorEventListener);
-            _raygunLogger?.Verbose("[RaygunBrowserInterop] Registered unhandled JS exception handler.");
+            // RWM: Register the .NET reference with JS. The JS side wires window 'error' and
+            //      'unhandledrejection' listeners that call back into RecordJsException.
+            await _jsRuntime.InvokeVoidAsync("window.raygunBlazor.initialize", _dotNetReference);
+            _raygunLogger?.Verbose("[RaygunBrowserInterop] Registered .NET reference and unhandled JS exception handlers.");
         }
 
         #endregion
@@ -200,17 +210,6 @@ namespace Raygun.Blazor
         /// </summary>
         public async ValueTask DisposeAsync()
         {
-            if (_errorEventListener is not null && Window is not null)
-            {
-                await Window.RemoveOnErrorEventListenerAsync(_errorEventListener);
-                await _errorEventListener.DisposeAsync();
-            }
-
-            if (Window is not null)
-            {
-                await Window.DisposeAsync();
-            }
-
             if (RaygunScriptReference is not null)
             {
                 await RaygunScriptReference.DisposeAsync();

--- a/src/Raygun.Blazor/wwwroot/Raygun.Blazor.js
+++ b/src/Raygun.Blazor/wwwroot/Raygun.Blazor.js
@@ -9,11 +9,92 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 window.raygunBlazor = {
     _raygunInterop: null,
+    _errorListener: null,
+    _rejectionListener: null,
     /**
-     *
+     * Wires the .NET interop reference and attaches null-safe global error
+     * listeners. Replaces the old KristofferStrube.Blazor.Window dependency,
+     * which crashed on iOS/Safari when ErrorEvent.error was null.
      */
     initialize: function (raygunInterop) {
         this._raygunInterop = raygunInterop;
+        if (this._errorListener === null) {
+            this._errorListener = (event) => {
+                const payload = window.raygunBlazor._buildErrorPayload(event);
+                if (payload === null) {
+                    return;
+                }
+                window.raygunBlazor._raygunInterop.invokeMethodAsync('RecordJsException', payload, ['UnhandledException', 'Blazor', 'JavaScript'], null).catch(() => { });
+            };
+            window.addEventListener('error', this._errorListener);
+        }
+        if (this._rejectionListener === null) {
+            this._rejectionListener = (event) => {
+                const payload = window.raygunBlazor._buildRejectionPayload(event);
+                if (payload === null) {
+                    return;
+                }
+                window.raygunBlazor._raygunInterop.invokeMethodAsync('RecordJsException', payload, ['UnhandledRejection', 'Blazor', 'JavaScript'], null).catch(() => { });
+            };
+            window.addEventListener('unhandledrejection', this._rejectionListener);
+        }
+    },
+    /**
+     * Builds a serializable payload from an ErrorEvent, defending against the
+     * common case (iOS/Safari, cross-origin scripts) where event.error is null.
+     */
+    _buildErrorPayload: function (event) {
+        const err = event && event.error ? event.error : null;
+        const message = (err && typeof err.message === 'string' && err.message)
+            || (event && event.message)
+            || '';
+        const name = (err && typeof err.name === 'string' && err.name) || 'Error';
+        if (!message && !err) {
+            // Cross-origin "Script error." with no useful data — skip.
+            return null;
+        }
+        return {
+            Name: name,
+            Message: message,
+            Stack: (err && typeof err.stack === 'string') ? err.stack : '',
+            FileName: (event && event.filename) || '',
+            LineNumber: (event && typeof event.lineno === 'number') ? event.lineno : 0,
+            ColumnNumber: (event && typeof event.colno === 'number') ? event.colno : 0,
+        };
+    },
+    /**
+     * Builds a serializable payload from a PromiseRejectionEvent.
+     */
+    _buildRejectionPayload: function (event) {
+        const reason = event ? event.reason : null;
+        if (reason instanceof Error) {
+            return {
+                Name: typeof reason.name === 'string' ? reason.name : 'UnhandledRejection',
+                Message: typeof reason.message === 'string' ? reason.message : '',
+                Stack: typeof reason.stack === 'string' ? reason.stack : '',
+                FileName: '',
+                LineNumber: 0,
+                ColumnNumber: 0,
+            };
+        }
+        if (reason === null || reason === undefined) {
+            return null;
+        }
+        let message;
+        try {
+            message = typeof reason === 'string' ? reason : JSON.stringify(reason);
+        }
+        catch (_a) {
+            message = String(reason);
+        }
+        return {
+            Name: 'UnhandledRejection',
+            Message: message,
+            Stack: '',
+            FileName: '',
+            LineNumber: 0,
+            ColumnNumber: 0,
+        };
     },
     /**
      *
@@ -28,7 +109,15 @@ window.raygunBlazor = {
      */
     recordException: function (exception, tags, customData) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield this._raygunInterop.invokeMethodAsync('RecordJsException', exception, tags, customData);
+            const payload = {
+                Name: (exception && typeof exception.name === 'string') ? exception.name : 'Error',
+                Message: (exception && typeof exception.message === 'string') ? exception.message : '',
+                Stack: (exception && typeof exception.stack === 'string') ? exception.stack : '',
+                FileName: '',
+                LineNumber: 0,
+                ColumnNumber: 0,
+            };
+            yield this._raygunInterop.invokeMethodAsync('RecordJsException', payload, tags, customData);
         });
     },
 };

--- a/src/Raygun.Blazor/wwwroot/Raygun.Blazor.ts
+++ b/src/Raygun.Blazor/wwwroot/Raygun.Blazor.ts
@@ -1,25 +1,133 @@
 (<any>window).raygunBlazor = {
     _raygunInterop: null,
+    _errorListener: null,
+    _rejectionListener: null,
 
     /**
-     * 
+     * Wires the .NET interop reference and attaches null-safe global error
+     * listeners. Replaces the old KristofferStrube.Blazor.Window dependency,
+     * which crashed on iOS/Safari when ErrorEvent.error was null.
      */
     initialize: function(raygunInterop: any) {
         this._raygunInterop = raygunInterop;
+
+        if (this._errorListener === null) {
+            this._errorListener = (event: ErrorEvent) => {
+                const payload = (<any>window).raygunBlazor._buildErrorPayload(event);
+                if (payload === null) {
+                    return;
+                }
+                (<any>window).raygunBlazor._raygunInterop.invokeMethodAsync(
+                    'RecordJsException',
+                    payload,
+                    ['UnhandledException', 'Blazor', 'JavaScript'],
+                    null,
+                ).catch(() => { /* swallow: never let Raygun itself surface a JS error. */ });
+            };
+            window.addEventListener('error', this._errorListener);
+        }
+
+        if (this._rejectionListener === null) {
+            this._rejectionListener = (event: PromiseRejectionEvent) => {
+                const payload = (<any>window).raygunBlazor._buildRejectionPayload(event);
+                if (payload === null) {
+                    return;
+                }
+                (<any>window).raygunBlazor._raygunInterop.invokeMethodAsync(
+                    'RecordJsException',
+                    payload,
+                    ['UnhandledRejection', 'Blazor', 'JavaScript'],
+                    null,
+                ).catch(() => { /* swallow */ });
+            };
+            window.addEventListener('unhandledrejection', this._rejectionListener);
+        }
     },
 
     /**
-     * 
+     * Builds a serializable payload from an ErrorEvent, defending against the
+     * common case (iOS/Safari, cross-origin scripts) where event.error is null.
+     */
+    _buildErrorPayload: function(event: ErrorEvent): any {
+        const err: any = event && (<any>event).error ? (<any>event).error : null;
+        const message = (err && typeof err.message === 'string' && err.message)
+            || (event && (<any>event).message)
+            || '';
+        const name = (err && typeof err.name === 'string' && err.name) || 'Error';
+
+        if (!message && !err) {
+            // Cross-origin "Script error." with no useful data — skip.
+            return null;
+        }
+
+        return {
+            Name: name,
+            Message: message,
+            Stack: (err && typeof err.stack === 'string') ? err.stack : '',
+            FileName: (event && (<any>event).filename) || '',
+            LineNumber: (event && typeof (<any>event).lineno === 'number') ? (<any>event).lineno : 0,
+            ColumnNumber: (event && typeof (<any>event).colno === 'number') ? (<any>event).colno : 0,
+        };
+    },
+
+    /**
+     * Builds a serializable payload from a PromiseRejectionEvent.
+     */
+    _buildRejectionPayload: function(event: PromiseRejectionEvent): any {
+        const reason: any = event ? (<any>event).reason : null;
+
+        if (reason instanceof Error) {
+            return {
+                Name: typeof reason.name === 'string' ? reason.name : 'UnhandledRejection',
+                Message: typeof reason.message === 'string' ? reason.message : '',
+                Stack: typeof reason.stack === 'string' ? reason.stack : '',
+                FileName: '',
+                LineNumber: 0,
+                ColumnNumber: 0,
+            };
+        }
+
+        if (reason === null || reason === undefined) {
+            return null;
+        }
+
+        let message: string;
+        try {
+            message = typeof reason === 'string' ? reason : JSON.stringify(reason);
+        } catch {
+            message = String(reason);
+        }
+
+        return {
+            Name: 'UnhandledRejection',
+            Message: message,
+            Stack: '',
+            FileName: '',
+            LineNumber: 0,
+            ColumnNumber: 0,
+        };
+    },
+
+    /**
+     *
      */
     recordBreadcrumb: async function(message: string, type: string, category: string, level: string, customData: Record<string, string>) {
         await this._raygunInterop.invokeMethodAsync('RecordJsBreadcrumb', message, type, category, level, customData);
     },
 
     /**
-     * 
+     *
      */
     recordException: async function(exception: Error, tags: string[], customData: Record<string, string>) {
-        await this._raygunInterop.invokeMethodAsync('RecordJsException', exception, tags, customData);
+        const payload = {
+            Name: (exception && typeof exception.name === 'string') ? exception.name : 'Error',
+            Message: (exception && typeof exception.message === 'string') ? exception.message : '',
+            Stack: (exception && typeof exception.stack === 'string') ? exception.stack : '',
+            FileName: '',
+            LineNumber: 0,
+            ColumnNumber: 0,
+        };
+        await this._raygunInterop.invokeMethodAsync('RecordJsException', payload, tags, customData);
     },
 };
 

--- a/src/Raygun.Samples.Blazor.WebAssembly/ViewModels/CounterViewModel.cs
+++ b/src/Raygun.Samples.Blazor.WebAssembly/ViewModels/CounterViewModel.cs
@@ -1,43 +1,43 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
-using KristofferStrube.Blazor.Window;
+using Microsoft.JSInterop;
 using Raygun.Blazor;
 
 namespace Raygun.Samples.Blazor.WebAssembly.ViewModels
 {
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     public class CounterViewModel
     {
 
         private readonly RaygunBlazorClient _raygunClient;
-        private readonly IWindowService _windowService;
+        private readonly IJSRuntime _jsRuntime;
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public int CurrentCount { get; private set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public Action? StateHasChanged { get; set; }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="raygunClient"></param>
-        /// <param name="windowService"></param>
-        public CounterViewModel(RaygunBlazorClient raygunClient, IWindowService windowService)
+        /// <param name="jsRuntime"></param>
+        public CounterViewModel(RaygunBlazorClient raygunClient, IJSRuntime jsRuntime)
         {
             _raygunClient = raygunClient;
-            _windowService = windowService;
+            _jsRuntime = jsRuntime;
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public Task IncrementCountAsync()
@@ -53,20 +53,17 @@ namespace Raygun.Samples.Blazor.WebAssembly.ViewModels
 
         public async Task ThrowException()
         {
-            var window = await _windowService.GetWindowAsync();
-            await window.PostMessageAsync("causeError");
+            await _jsRuntime.InvokeVoidAsync("postMessage", "causeError", "*");
         }
 
         public async Task SendCustomJsException()
         {
-            var window = await _windowService.GetWindowAsync();
-            await window.PostMessageAsync("recordException");
+            await _jsRuntime.InvokeVoidAsync("postMessage", "recordException", "*");
         }
 
         public async Task SendCustomJsBreadcrumb()
         {
-            var window = await _windowService.GetWindowAsync();
-            await window.PostMessageAsync("recordBreadcrumb");
+            await _jsRuntime.InvokeVoidAsync("postMessage", "recordBreadcrumb", "*");
         }
     }
 }

--- a/src/Raygun.Tests.Blazor.Server/RaygunExceptionCatcherTests.cs
+++ b/src/Raygun.Tests.Blazor.Server/RaygunExceptionCatcherTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 using System.Text.Json;
-using KristofferStrube.Blazor.Window;
 using Raygun.Blazor;
 using MockHttp;
 using Raygun.Tests.Blazor.Server.Components;
@@ -52,7 +51,6 @@ namespace Raygun.Tests.Blazor.Server
                 // Create RaygunBlazorClient with mocked HttpClient
                 services.Configure<RaygunSettings>(context.Configuration.GetSection("Raygun"));
                 services.AddScoped<RaygunBrowserInterop>();
-                services.AddWindowService();
                 services.AddSingleton<IHttpClientFactory>(new MockHttpClientFactory(_httpClient));
                 services.AddScoped<RaygunBlazorClient>();
 

--- a/src/Raygun.Tests.Blazor/Models/ErrorDetailsTest.cs
+++ b/src/Raygun.Tests.Blazor/Models/ErrorDetailsTest.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using FluentAssertions;
-using KristofferStrube.Blazor.WebIDL.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Raygun.Blazor;
 using Raygun.Blazor.Models;
 
 namespace Raygun.Tests.Blazor.Models;
@@ -29,16 +28,16 @@ public class ErrorDetailsTest
     public void ErrorDetails_NewInstance_JavaScriptException()
     {
         // Define JavaScript exception
-        var stacktrace = @"causeErrors@http://localhost:5010/myfunctions.js:7:9 
-        window.onmessage@http://localhost:5010/:21:17
-        EventHandlerNonNull*@http://localhost:5010/:18:9";
-        var exception = new WebIDLException("Test", stacktrace, null!);
+        var stacktrace = "causeErrors@http://localhost:5010/myfunctions.js:7:9\n"
+            + "window.onmessage@http://localhost:5010/:21:17\n"
+            + "EventHandlerNonNull*@http://localhost:5010/:18:9";
+        var exception = new JsUnhandledException("TypeError", "Test", stacktrace);
 
         // Parse exception
         var errorDetails = new ErrorDetails(exception);
 
-        // Check details
-        errorDetails.ClassName.Should().Be("KristofferStrube.Blazor.WebIDL.Exceptions.WebIDLException");
+        // Check details — ClassName surfaces the JS error name (e.g. "TypeError"), not a .NET type.
+        errorDetails.ClassName.Should().Be("TypeError");
         errorDetails.Message.Should().Be("Test");
 
         // Check parsed stack trace
@@ -48,5 +47,23 @@ public class ErrorDetailsTest
         traceDetails.FileName.Should().Be("http://localhost:5010/myfunctions.js");
         traceDetails.LineNumber.Should().Be(7);
         traceDetails.MethodName.Should().Be("causeErrors");
+    }
+
+    /// <summary>
+    /// Regression test for issue #96: when the browser dispatches an ErrorEvent
+    /// with no backing Error (e.g. iOS/Safari, cross-origin scripts), Raygun
+    /// must still produce a usable ErrorDetails without throwing.
+    /// </summary>
+    [TestMethod]
+    public void ErrorDetails_NewInstance_JavaScriptException_NullStackAndName()
+    {
+        var exception = new JsUnhandledException(name: null, message: null, stack: null);
+
+        Action build = () => _ = new ErrorDetails(exception);
+
+        build.Should().NotThrow();
+        var errorDetails = new ErrorDetails(exception);
+        errorDetails.Message.Should().Be("JavaScript error");
+        errorDetails.StackTrace.Should().BeNull();
     }
 }

--- a/src/Raygun.Tests.Blazor/RaygunBlazorClientTests.cs
+++ b/src/Raygun.Tests.Blazor/RaygunBlazorClientTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Bunit;
 using CloudNimble.Breakdance.Blazor;
 using FluentAssertions;
-using KristofferStrube.Blazor.Window;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -76,7 +75,6 @@ namespace Raygun.Tests.Blazor
                 // Create RaygunBlazorClient with mocked HttpClient
                 services.Configure<RaygunSettings>(context.Configuration.GetSection("Raygun"));
                 services.AddScoped<RaygunBrowserInterop>();
-                services.AddWindowService();
                 services.AddSingleton<IHttpClientFactory>(new MockHttpClientFactory(_httpClient));
                 services.AddSingleton<IRaygunUserProvider>(new FakeRaygunUserProvider());
 


### PR DESCRIPTION
## fix(#96): Remove KristofferStrube.Blazor.Window dependency

### Description :memo:

- **Purpose**: Fixes [#96](https://github.com/MindscapeHQ/raygun4blazor/issues/96). On iOS/Safari, the alpha `KristofferStrube.Blazor.Window` package crashed when the browser fired an `ErrorEvent` with a null `error` property, causing Raygun itself to surface JS errors.
- **Approach**: Drop the package and own the unhandled-error path. Our own JS handler attaches null-safe `error` and `unhandledrejection` listeners and forwards a Raygun-owned payload to .NET.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

:point_right: Removed `KristofferStrube.Blazor.Window` and all `IWindowService` registrations across `Raygun.Blazor`, `.Server`, `.WebAssembly`, and `.Maui`.
:point_right: Added `JsUnhandledException` and `JsErrorPayload`; replaced `WebIDLException` handling in `ErrorDetails`. JS errors now have `ClassName` set to the JS error name (e.g. `"TypeError"`) instead of the WebIDL class name.
:point_right: Rewrote `Raygun.Blazor.ts` with null-safe `window.error` + `unhandledrejection` listeners. Public `window.raygunBlazor.recordException` / `recordBreadcrumb` API is unchanged.
:point_right: Added a regression test covering the null-error scenario from the issue.
:point_right: Bumped `Microsoft.AspNetCore.Components` and `Microsoft.Extensions.DependencyInjection` to `10.0.7` in the test project to resolve a pre-existing `NU1605` conflict from bunit `2.7.2` (unrelated to #96, isolated in its own commit).

### Screenshots :camera:

N/A — runtime behavior change.

### Test plan :test_tube:

1. Build the solution and run `dotnet test` — expect 23/23 passing, including the new null-error regression test.
2. Run the WebAssembly sample on iOS/Safari, click **"Throw Unhandled JS Exception"**, and confirm a single Raygun report is sent with **no** `null is not an object` / `Maximum call stack size exceeded` / `JSObjectReference from 'null'` errors in the console.
3. Repeat in Chrome/Firefox/Edge to confirm no regression on other browsers.
4. In DevTools, run `Promise.reject(new Error('test'))` and confirm a single report tagged `UnhandledRejection` reaches Raygun (new coverage).
5. Click **"Send Custom JS Exception"** and **"Record JS Breadcrumb"** to confirm the public JS API still works.
6. Set `CatchUnhandledExceptions` to `false` and confirm step 2 no longer auto-reports, but step 5 still does.
7. Inspect a captured request and confirm `details.error.className` contains the JS error name (e.g. `"TypeError"`) — flag if any Raygun dashboard/alert was keyed on the old WebIDL class name.

### Author to check :eyeglasses:

- [x] Project and all contained modules builds successfully
- [x] Self-/dev-tested
- [x] Unit/UI/Automation/Integration tests provided where applicable
- [x] Code is written to standards
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:

- [ ] Project and all contained modules builds successfully
- [ ] Change has been dev-/reviewer-tested, where possible
- [ ] Unit/UI/Automation/Integration tests provided where applicable
- [ ] Code is written to standards
- [ ] Appropriate documentation written (code comments, internal docs)